### PR TITLE
Configuration

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	c "github.com/firstrow/logvoyage/configuration"
 	"github.com/firstrow/logvoyage/common"
 	"github.com/firstrow/logvoyage/web_socket"
 	"github.com/garyburd/redigo/redis"
@@ -40,7 +41,7 @@ func Start(userTcpDsn, userHttpDsn string) {
 }
 
 func initRedis() {
-	r, err := redis.Dial("tcp", ":6379")
+	r, err := redis.Dial("tcp", c.ReadConf().Redis.GetURI())
 	if err != nil {
 		log.Fatal("Cannot connect to redis")
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codegangsta/cli"
 	"log"
 
+	config "github.com/firstrow/logvoyage/configuration"
 	"github.com/firstrow/logvoyage/backend"
 	"github.com/firstrow/logvoyage/common"
 	"github.com/firstrow/logvoyage/web"
@@ -14,7 +15,12 @@ var CreateUsersIndex = cli.Command{
 	Usage:       "Will create `user` index in ES",
 	Description: "",
 	Action:      createUsersIndexFunc,
-	Flags:       []cli.Flag{},
+	Flags:       []cli.Flag{
+		cli.StringFlag{
+			Name:  "config",
+			Usage: "Use different config file. Default is /etc/logvoyage.yml",
+		},
+	},
 }
 
 var DeleteIndex = cli.Command{
@@ -22,7 +28,12 @@ var DeleteIndex = cli.Command{
 	Usage:       "Will delete elastic search index",
 	Description: "",
 	Action:      deleteIndexFunc,
-	Flags:       []cli.Flag{},
+	Flags:       []cli.Flag{
+		cli.StringFlag{
+			Name:  "config",
+			Usage: "Use different config file. Default is /etc/logvoyage.yml",
+		},
+	},
 }
 
 var CreateIndex = cli.Command{
@@ -30,7 +41,12 @@ var CreateIndex = cli.Command{
 	Usage:       "Create search index",
 	Description: "",
 	Action:      createIndexFunc,
-	Flags:       []cli.Flag{},
+	Flags:       []cli.Flag{
+		cli.StringFlag{
+			Name:  "config",
+			Usage: "Use different config file. Default is /etc/logvoyage.yml",
+		},
+	},
 }
 
 var StartBackendServer = cli.Command{
@@ -38,6 +54,10 @@ var StartBackendServer = cli.Command{
 	Usage:  "Starts TCP server to accept logs from clients",
 	Action: startBackendServer,
 	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "config",
+			Usage: "Use different config file. Default is /etc/logvoyage.yml",
+		},
 		cli.StringFlag{
 			Name:  "tcp-dsn",
 			Usage: "Use different TCP host and port. Default is :27077",
@@ -56,6 +76,10 @@ var StartWebServer = cli.Command{
 	Action:      startWebServer,
 	Flags: []cli.Flag{
 		cli.StringFlag{
+			Name:  "config",
+			Usage: "Use different config file. Default is /etc/logvoyage.yml",
+		},
+		cli.StringFlag{
 			Name:  "webui-dsn",
 			Usage: "Use different host and port for webio. Default is :3000",
 		},
@@ -68,6 +92,10 @@ var StartAll = cli.Command{
 	Description: "",
 	Action:      startAll,
 	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "config",
+			Usage: "Use different config file. Default is /etc/logvoyage.yml",
+		},
 		cli.StringFlag{
 			Name:  "tcp-dsn",
 			Usage: "Use different TCP host and port. Default is :27077",
@@ -83,20 +111,33 @@ var StartAll = cli.Command{
 	},
 }
 
+func loadConfig(s string) *config.Config {
+	if len(s) > 0 {
+		config.ReadConf(s)
+	}else{
+		config.ReadConf()
+	}
+	return &config.Cfg
+}
+
 func startBackendServer(c *cli.Context) {
+	loadConfig(c.String("config"))
 	backend.Start(c.String("tcp-dsn"), c.String("http-dsn"))
 }
 
 func startWebServer(c *cli.Context) {
+	loadConfig(c.String("config"))
 	web.Start(c.String("webui-dsn"))
 }
 
 func startAll(c *cli.Context) {
+	loadConfig(c.String("config"))
 	go backend.Start(c.String("tcp-dsn"), c.String("http-dsn"))
 	web.Start(c.String("webui-dsn"))
 }
 
 func createUsersIndexFunc(c *cli.Context) {
+	cfg := loadConfig(c.String("config"))
 	log.Println("Creating users index in ElasticSearch")
 	settings := `{
 		"settings": {
@@ -117,11 +158,12 @@ func createUsersIndexFunc(c *cli.Context) {
 			}
 		}
 	}`
-	result, _ := common.SendToElastic("users", "PUT", []byte(settings))
+	result, _ := common.SendToElastic(cfg.Indexes.User, "PUT", []byte(settings))
 	log.Println(result)
 }
 
 func createIndexFunc(c *cli.Context) {
+	loadConfig(c.String("config"))
 	settings := `{
 		"settings": {
 			"index": {
@@ -136,6 +178,7 @@ func createIndexFunc(c *cli.Context) {
 }
 
 func deleteIndexFunc(c *cli.Context) {
+	loadConfig(c.String("config"))
 	if len(c.Args()) > 0 {
 		for _, name := range c.Args() {
 			result, _ := common.SendToElastic(name, "DELETE", nil)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -10,6 +10,14 @@ import (
 	"github.com/firstrow/logvoyage/web"
 )
 
+var ConfigFile = cli.Command{
+	Name:		 "configuration",
+	Usage:		 "Print in the terminal, the configuration yaml struct.",
+	Description: "",
+	Action:		 configFileFunc,
+	Flags:		 []cli.Flag{},
+}
+
 var CreateUsersIndex = cli.Command{
 	Name:        "create_users_index",
 	Usage:       "Will create `user` index in ES",
@@ -118,6 +126,10 @@ func loadConfig(s string) *config.Config {
 		config.ReadConf()
 	}
 	return &config.Cfg
+}
+
+func configFileFunc(c *cli.Context) {
+	config.CreateConfFile()
 }
 
 func startBackendServer(c *cli.Context) {

--- a/common/user.go
+++ b/common/user.go
@@ -10,6 +10,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/xlab/handysort"
 	"golang.org/x/crypto/bcrypt"
+
+	c "github.com/firstrow/logvoyage/configuration"
 )
 
 type User struct {
@@ -115,7 +117,7 @@ func FindUserByApiKey(apiKey string) (*User, error) {
 
 func (this *User) Save() {
 	doc := goes.Document{
-		Index:  "users",
+		Index:  c.ReadConf().Indexes.User,
 		Type:   "user",
 		Id:     this.Id,
 		Fields: this,
@@ -142,7 +144,7 @@ func FindUserBy(key string, value string) (*User, error) {
 		},
 	}
 
-	searchResults, err := GetConnection().Search(query, []string{"users"}, []string{"user"}, url.Values{})
+	searchResults, err := GetConnection().Search(query, []string{c.ReadConf().Indexes.User}, []string{"user"}, url.Values{})
 
 	if err != nil {
 		return nil, ErrSendingElasticSearchRequest

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -1,0 +1,27 @@
+# Configuration
+
+Displayed all configuration options.
+
+----------
+
+## First level
+
+All keys of first level configuration.
+
+* `debug` - bool
+* `indexes` - IndexesStruct
+
+----------
+
+## IndexesStruct
+
+Configuration of IndexesStruct.
+
+* `user` - string - Default: `users`
+  * Sets the index name to the users in ES.
+
+```yaml
+indexes:
+  user: users
+```
+

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -1,0 +1,69 @@
+package configuration
+
+import (
+    "io/ioutil"
+    "fmt"
+
+    "gopkg.in/yaml.v2"
+    "github.com/cosiner/gohper/errors"
+)
+
+var (
+    // Cfg is a configuration parsed from yaml file
+    Cfg Config
+
+    // AlternativeConfPath used from testing to read a diferent configuration file
+    AlternativeConfPath string
+
+    initialized bool
+)
+
+// Config define a struct used to readded the configuration settings
+type Config struct {
+    Debug       bool            `yaml:"debug"`
+    Indexes     IndexesStruct   `yaml:"indexes"`
+}
+
+// SetDefaults set the defaults values of all keys has not configured
+func (cfg *Config) SetDefaults() *Config {
+    cfg.Indexes.SetDefaults()
+    return cfg
+}
+
+// CreateConfFile print to terminal the yaml struct to generate a new default configuration file
+func CreateConfFile() {
+    c := Config{
+        Debug: false,
+        Indexes: IndexesStruct{
+            User: "users",
+        },
+    }
+    b, err := yaml.Marshal(c)
+    errors.Fatalln(err)
+    fmt.Println(string(b))
+}
+
+// ReadConf open the configuration file e parse the content to a ney `Config` variable
+func ReadConf(str ...string) *Config {
+    if ! initialized {
+        var filePath string
+
+        if len(str) == 0 && AlternativeConfPath != "" {
+            filePath = AlternativeConfPath
+        }else if len(str) == 0 {
+            filePath = "/etc/logvoyage.yml"
+        }else{
+            filePath = str[0]
+        }
+
+        yamlFile, err := ioutil.ReadFile(filePath)
+        errors.Fatalln(err)
+
+        err = yaml.Unmarshal(yamlFile, &Cfg)
+        errors.Fatalln(err)
+
+        Cfg.SetDefaults()
+        initialized = true
+    }
+    return &Cfg
+}

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -22,11 +22,13 @@ var (
 type Config struct {
     Debug       bool            `yaml:"debug"`
     Indexes     IndexesStruct   `yaml:"indexes"`
+    Redis       RedisStruct     `yaml:"redis"`
 }
 
 // SetDefaults set the defaults values of all keys has not configured
 func (cfg *Config) SetDefaults() *Config {
     cfg.Indexes.SetDefaults()
+    cfg.Redis.SetDefaults()
     return cfg
 }
 
@@ -36,6 +38,10 @@ func CreateConfFile() {
         Debug: false,
         Indexes: IndexesStruct{
             User: "users",
+        },
+        Redis: RedisStruct{
+            Host: "localhost",
+            Port: 6379,
         },
     }
     b, err := yaml.Marshal(c)

--- a/configuration/config_test.go
+++ b/configuration/config_test.go
@@ -1,0 +1,10 @@
+package configuration
+
+import "testing"
+
+func TestReadConfiguration(t *testing.T) {
+	cfg := ReadConf("resources/logvoyage.yml")
+	if cfg.Indexes.User != "logvoyage_user" {
+		t.Errorf("Expect that Indexes.User to be eql: \"logvoyage_user\" and not: \"%s\"", cfg.Indexes.User)
+	}
+}

--- a/configuration/resources/logvoyage.yml
+++ b/configuration/resources/logvoyage.yml
@@ -1,0 +1,3 @@
+debug: false
+indexes:
+  user: logvoyage_user

--- a/configuration/resources/logvoyage.yml
+++ b/configuration/resources/logvoyage.yml
@@ -1,3 +1,6 @@
 debug: false
 indexes:
   user: logvoyage_user
+redis:
+  port: 6379
+  host: localhost

--- a/configuration/struct_indexes.go
+++ b/configuration/struct_indexes.go
@@ -1,0 +1,11 @@
+package configuration
+
+// IndexesStruct define de struct of indexes names to ElasticSearch
+type IndexesStruct struct {
+    User    string  `yaml:"user"`
+}
+
+// SetDefaults set the defaults values of all keys has not configured
+func (s *IndexesStruct) SetDefaults() {
+    if len(s.User) == 0  { s.User = "users" }
+}

--- a/configuration/struct_redis.go
+++ b/configuration/struct_redis.go
@@ -1,0 +1,20 @@
+package configuration
+
+import "strconv"
+
+// RedisStruct define de struct of indexes names to ElasticSearch
+type RedisStruct struct {
+    Host	string 	`yaml:"host"`
+    Port	int		`yaml:"port"`
+}
+
+// SetDefaults set the defaults values of all keys has not configured
+func (s *RedisStruct) SetDefaults() {
+    if len(s.Host) == 0  { s.Host = "localhost" }
+    if s.Port <= 0       { s.Port = 6379 }
+}
+
+// GetURI returns the uri to create conecction
+func (s *RedisStruct) GetURI() string {
+	return s.Host + ":" + strconv.Itoa(s.Port)
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "LogVoyage"
 	app.Commands = []cli.Command{
+		commands.ConfigFile,
 		commands.StartBackendServer,
 		commands.StartWebServer,
 		commands.StartAll,

--- a/web/routers/users/register.go
+++ b/web/routers/users/register.go
@@ -8,6 +8,7 @@ import (
 	"github.com/belogik/goes"
 	"github.com/nu7hatch/gouuid"
 
+	c "github.com/firstrow/logvoyage/configuration"
 	"github.com/firstrow/logvoyage/common"
 	"github.com/firstrow/logvoyage/web/context"
 )
@@ -54,7 +55,7 @@ func Register(ctx *context.Context) {
 			}
 
 			doc := goes.Document{
-				Index: "users",
+				Index: c.ReadConf().Indexes.User,
 				Type:  "user",
 				Fields: map[string]string{
 					"email":    form.Email,

--- a/web_socket/web_socket.go
+++ b/web_socket/web_socket.go
@@ -18,6 +18,7 @@ import (
 	"log"
 	"net/http"
 
+	c "github.com/firstrow/logvoyage/configuration"
 	"github.com/firstrow/logvoyage/common"
 
 	"code.google.com/p/go.net/websocket"
@@ -61,7 +62,7 @@ func checkError(err error) {
 
 // Listen to Redis and send messages to clients
 func startListetingRedis() {
-	c, err := redis.Dial("tcp", ":6379")
+	c, err := redis.Dial("tcp", c.ReadConf().Redis.GetURI())
 	checkError(err)
 	c.Send("SUBSCRIBE", redisChannel)
 	c.Flush()


### PR DESCRIPTION
Place the possibility of setting. Via configuration files.

I suggest in the YAML format.

Reason:
- [x] Greater flexibility.
- [x] Already exists "users" index in ElasticSearch.
- [x] Url different for the connection to the Redis (not yet implemented).
- [ ] Url different for the connection to the ElasticSearch (not yet implemented).
- [ ] Different cryptographic token (not yet implemented).

How it would work:
- Add the flag `config` in command to the absolute path of the configuration file.
- Not being required. Because it would look in the default location: `/etc/logvoyage.yml`
- To generate the default configuration file, use the command: `logvoyage configuration > /etc/logvoyage.yml`

What do you think?
